### PR TITLE
Combine foreign imports with same signature. Does not produce short names

### DIFF
--- a/RegistryProcessor/RegistryProcessor.cabal
+++ b/RegistryProcessor/RegistryProcessor.cabal
@@ -26,7 +26,7 @@ executable RegistryProcessor
     containers >= 0.3 && < 0.6,
     hxt        >= 9.3 && < 9.4,
     directory  >= 1.0 && < 1.3,
-    filepath   >= 1.0 && < 1.4
+    filepath   >= 1.0 && < 1.5
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall


### PR DESCRIPTION
Two directions on compression:

Create a huffman table from the current set of functions & then rewrite getDynName to output the compression in base-53

Create the list of signatures before printing commands. Pass list to showCommand. Name the functions dyn1, dyn2, dyn3, etc