### PR TITLE
Use pkgconfig to get flags needed for GL library.

### DIFF
--- a/OpenGLRaw.cabal
+++ b/OpenGLRaw.cabal
@@ -709,6 +709,12 @@ library
     CPP
     PatternSynonyms
     ScopedTypeVariables
+  if os(openbsd)
+    -- OpenBSD keeps OpenGL libs under /usr/X11R6. Without the following line,
+    -- we get an error like this:
+    --   cabal: Missing dependency on a foreign library:
+    --   * Missing (or bad) C library: GL
+    pkgconfig-depends: gl
   if os(windows) && flag(UseNativeWindowsLibraries)
     if arch(i386)
       cpp-options: "-DCALLCONV=stdcall"


### PR DESCRIPTION
This gets it to build on OpenBSD. Before this change, the GL library isn't
found:

    Configuring library for OpenGLRaw-3.3.4.0..
    cabal: Missing dependency on a foreign library:
    * Missing (or bad) C library: GL