### PR TITLE
Support GHC 9.4.2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,6 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.4.2
+            compilerKind: ghc
+            compilerVersion: 9.4.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.2.1
             compilerKind: ghc
             compilerVersion: 9.2.1
@@ -76,7 +81,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
@@ -87,7 +92,7 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME" freeglut3-dev
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
           fi

--- a/OpenGLRaw.cabal
+++ b/OpenGLRaw.cabal
@@ -36,6 +36,7 @@ tested-with:
   GHC == 8.10.7
   GHC == 9.0.1
   GHC == 9.2.1
+  GHC == 9.4.3
 cabal-version: >= 1.10
 extra-source-files:
   CHANGELOG.md
@@ -699,7 +700,7 @@ library
     containers   >= 0.3     && < 0.7,
     fixed        >= 0.2     && < 0.4,
     half         >= 0.2.2.1 && < 0.4,
-    text         >= 0.1     && < 1.3,
+    text         >= 0.1     && < 2.1,
     transformers >= 0.2     && < 0.7
   default-language: Haskell2010
   ghc-options: -Wall


### PR DESCRIPTION
* Relaxed bound for text-2.0 (as recommended in #45)
* Built locally for GHC 9.4.2
* Allowed GHC 9.4.2 in CI