### PR TITLE
Bump CI to ubuntu-22.04

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -14,8 +14,12 @@
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     timeout-minutes:
       60
     container:


### PR DESCRIPTION
Fix CI by bumping the ubuntu version to `22.04`. Also fix the double-triggering behavior for a push and a pull request, so that we now only get one build started when pushing to a PR.